### PR TITLE
Security/caps selinux

### DIFF
--- a/docker/archiv/compose.yaml
+++ b/docker/archiv/compose.yaml
@@ -5,6 +5,12 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
     environment:
       TZ: "Europe/Berlin"
     networks:
@@ -28,6 +34,13 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
+      - "DAC_OVERRIDE"
     environment:
       MARIADB_AUTO_UPGRADE: "1"
       MARIADB_DISABLE_UPGRADE_BACKUP: "1"
@@ -53,6 +66,14 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
+      - "FOWNER"
+      - "DAC_OVERRIDE"
     volumes:
       - "${DOCKER_DATA_DIR:?error}/${COMPOSE_PROJECT_NAME:?error}/db-backups:/backup:z"
     environment:

--- a/docker/arma3sync-repo/compose.yaml
+++ b/docker/arma3sync-repo/compose.yaml
@@ -6,6 +6,10 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "NET_BIND_SERVICE"
     volumes:
       - "arma3sync-repo:/srv:ro"
       - "./browse.html:/templates/browse.html:ro,Z"

--- a/docker/armaservermanager/compose.yaml
+++ b/docker/armaservermanager/compose.yaml
@@ -5,6 +5,13 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
+      - "DAC_OVERRIDE"
     ports:
       - "3306:3306"
     environment:
@@ -30,6 +37,14 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
+      - "FOWNER"
+      - "DAC_OVERRIDE"
     volumes:
       - "${DOCKER_DATA_DIR:?error}/${COMPOSE_PROJECT_NAME:?error}/db-backups:/backup:z"
     environment:

--- a/docker/authentik/compose.yaml
+++ b/docker/authentik/compose.yaml
@@ -6,6 +6,13 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "FOWNER"
+      - "SETUID"
+      - "SETGID"
     depends_on:
       db:
         condition: "service_healthy"
@@ -51,12 +58,19 @@ services:
     container_name: "${COMPOSE_PROJECT_NAME:?error}-worker"
     command: "worker"
     restart: "unless-stopped"
+    user: "root"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "FOWNER"
+      - "SETUID"
+      - "SETGID"
     depends_on:
       db:
         condition: "service_healthy"
-    user: "root"
     volumes:
       - "${DOCKER_DATA_DIR:?error}/${COMPOSE_PROJECT_NAME:?error}/data:/data:z"
       - "${DOCKER_DATA_DIR:?error}/${COMPOSE_PROJECT_NAME:?error}/templates:/templates:z"
@@ -83,6 +97,14 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
+      - "FOWNER"
+      - "DAC_OVERRIDE"
     healthcheck:
       interval: "30s"
       retries: 5
@@ -105,6 +127,14 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
+      - "FOWNER"
+      - "DAC_OVERRIDE"
     volumes:
       - "${DOCKER_DATA_DIR:?error}/${COMPOSE_PROJECT_NAME:?error}/db-backups:/backup:z"
     environment:

--- a/docker/beszel/compose.yaml
+++ b/docker/beszel/compose.yaml
@@ -5,6 +5,8 @@ services:
     restart: unless-stopped
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
     environment:
       TZ: "${TZ:-Europe/Berlin}"
       USER_CREATION: "true"

--- a/docker/bot-nachrichtenoffizier/compose.yaml
+++ b/docker/bot-nachrichtenoffizier/compose.yaml
@@ -5,6 +5,14 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
+      - "FOWNER"
+      - "DAC_OVERRIDE"
     environment:
       DISCORD_TOKEN: "${DISCORD_TOKEN:?error}"
       CLIENT_ID: "${CLIENT_ID:?error}"

--- a/docker/cloudbeaver/compose.yaml
+++ b/docker/cloudbeaver/compose.yaml
@@ -5,6 +5,14 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
+      - "FOWNER"
+      - "DAC_OVERRIDE"
     environment:
       TZ: "Europe/Berlin"
     networks:

--- a/docker/coredns/compose.yaml
+++ b/docker/coredns/compose.yaml
@@ -6,6 +6,10 @@ services:
     command: "-conf /etc/coredns/Corefile -dns.port 53"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "NET_BIND_SERVICE"
     ports:
       - "${IPV4:?error}:53:53"
       - "${IPV4:?error}:53:53/udp"
@@ -18,37 +22,37 @@ services:
 configs:
   corefile:
     content: |
-      ${DOMAINNAME?error} {
+      ${DOMAINNAME:?error} {
         log
         errors
       
         hosts {
-          ${IPV4:?error} backup.${DOMAINNAME?error}
-          ${IPV6:?error} backup.${DOMAINNAME?error}
+          ${IPV4:?error} backup.${DOMAINNAME:?error}
+          ${IPV6:?error} backup.${DOMAINNAME:?error}
       
-          ${IPV4:?error} komodo.${DOMAINNAME?error}
-          ${IPV6:?error} komodo.${DOMAINNAME?error}
+          ${IPV4:?error} komodo.${DOMAINNAME:?error}
+          ${IPV6:?error} komodo.${DOMAINNAME:?error}
       
-          ${IPV4:?error} docker0.${DOMAINNAME?error}
-          ${IPV6:?error} docker0.${DOMAINNAME?error}
+          ${IPV4:?error} docker0.${DOMAINNAME:?error}
+          ${IPV6:?error} docker0.${DOMAINNAME:?error}
       
-          ${IPV4:?error} traefik.${DOMAINNAME?error}
-          ${IPV6:?error} traefik.${DOMAINNAME?error}
+          ${IPV4:?error} traefik.${DOMAINNAME:?error}
+          ${IPV6:?error} traefik.${DOMAINNAME:?error}
       
-          ${IPV4:?error} traefik-log-dashboard.${DOMAINNAME?error}
-          ${IPV6:?error} traefik-log-dashboard.${DOMAINNAME?error}
+          ${IPV4:?error} traefik-log-dashboard.${DOMAINNAME:?error}
+          ${IPV6:?error} traefik-log-dashboard.${DOMAINNAME:?error}
       
-          ${IPV4:?error} beszel.${DOMAINNAME?error}
-          ${IPV6:?error} beszel.${DOMAINNAME?error}
+          ${IPV4:?error} beszel.${DOMAINNAME:?error}
+          ${IPV6:?error} beszel.${DOMAINNAME:?error}
       
-          ${IPV4:?error} ifxmetrics.${DOMAINNAME?error}
-          ${IPV6:?error} ifxmetrics.${DOMAINNAME?error}
+          ${IPV4:?error} ifxmetrics.${DOMAINNAME:?error}
+          ${IPV6:?error} ifxmetrics.${DOMAINNAME:?error}
       
-          ${IPV4:?error} asm.${DOMAINNAME?error}
-          ${IPV6:?error} asm.${DOMAINNAME?error}
+          ${IPV4:?error} asm.${DOMAINNAME:?error}
+          ${IPV6:?error} asm.${DOMAINNAME:?error}
       
-          ${IPV4:?error} dbs.${DOMAINNAME?error}
-          ${IPV6:?error} dbs.${DOMAINNAME?error}
+          ${IPV4:?error} dbs.${DOMAINNAME:?error}
+          ${IPV6:?error} dbs.${DOMAINNAME:?error}
       
           fallthrough
         }

--- a/docker/grafana/compose.yaml
+++ b/docker/grafana/compose.yaml
@@ -5,6 +5,8 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
     depends_on:
       db:
         condition: "service_healthy"
@@ -35,6 +37,14 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
+      - "FOWNER"
+      - "DAC_OVERRIDE"
     healthcheck:
       interval: "30s"
       retries: 5
@@ -57,6 +67,14 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
+      - "FOWNER"
+      - "DAC_OVERRIDE"
     volumes:
       - "${DOCKER_DATA_DIR:?error}/${COMPOSE_PROJECT_NAME:?error}/db-backups:/backup:z"
     environment:

--- a/docker/ifxmetrics/compose.yaml
+++ b/docker/ifxmetrics/compose.yaml
@@ -5,6 +5,14 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
+      - "FOWNER"
+      - "DAC_OVERRIDE"
     ports:
       - "8086:8086"
     networks:

--- a/docker/komodo/compose.yaml
+++ b/docker/komodo/compose.yaml
@@ -8,6 +8,13 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
+      - "DAC_OVERRIDE"
     volumes:
       - "${DOCKER_DATA_DIR:?error}/${COMPOSE_PROJECT_NAME:?error}/mongo-data:/data/db:z"
       - "${DOCKER_DATA_DIR:?error}/${COMPOSE_PROJECT_NAME:?error}/mongo-config:/data/configdb:z"
@@ -33,6 +40,8 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
     depends_on:
       - "mongo"
     ports:

--- a/docker/kopia/compose.yaml
+++ b/docker/kopia/compose.yaml
@@ -8,16 +8,19 @@ services:
     security_opt:
       - "label:disable" # Disable SELinux labels for compatibility with Kopia
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "DAC_READ_SEARCH"
     command:
       - "server"
       - "start"
-      - "--disable-csrf-token-checks"
       - "--insecure"
       - "--address=0.0.0.0:51515"
-      - "--server-username=${SERVER_USERNAME?error}"
-      - "--server-password=${SERVER_PASSWORD?error}"
     environment:
       KOPIA_PASSWORD: "${REPOSITORY_PASSWORD:?error}"
+      KOPIA_SERVER_USERNAME: "${SERVER_USERNAME:?error}"
+      KOPIA_SERVER_PASSWORD: "${SERVER_PASSWORD:?error}"
       USER: "${USER:-kopia}"
       TZ: "Europe/Berlin"
     networks:

--- a/docker/legacy-website-beta/compose.yaml
+++ b/docker/legacy-website-beta/compose.yaml
@@ -5,6 +5,12 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
     environment:
       TZ: "Europe/Berlin"
       APP_NAME: "Tactical Training Team | Arma MilSim Community"
@@ -35,7 +41,7 @@ services:
       traefik.http.routers.legacy-website-beta.service: "legacy-website-beta"
       traefik.http.services.legacy-website-beta.loadbalancer.server.port: 80
     volumes:
-      - "missions:/missions:Z"
+      - "missions:/missions:z"
     depends_on:
       db:
         condition: "service_healthy"
@@ -45,6 +51,13 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
+      - "DAC_OVERRIDE"
     environment:
       MARIADB_AUTO_UPGRADE: "1"
       MARIADB_DISABLE_UPGRADE_BACKUP: "1"
@@ -70,6 +83,14 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
+      - "FOWNER"
+      - "DAC_OVERRIDE"
     volumes:
       - "${DOCKER_DATA_DIR:?error}/${COMPOSE_PROJECT_NAME:?error}/db-backups:/backup:z"
     environment:

--- a/docker/legacy-website-prod/compose.yaml
+++ b/docker/legacy-website-prod/compose.yaml
@@ -5,6 +5,12 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
     environment:
       TZ: "Europe/Berlin"
       APP_NAME: "Tactical Training Team | Arma MilSim Community"
@@ -38,7 +44,7 @@ services:
       traefik.http.middlewares.redirect-www-to-non-www.redirectregex.regex: "^https://www\\.(.*)"
       traefik.http.middlewares.redirect-www-to-non-www.redirectregex.replacement: "https://$$1"
     volumes:
-      - "missions:/missions:Z"
+      - "missions:/missions:z"
     depends_on:
       db:
         condition: "service_healthy"
@@ -49,6 +55,13 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
+      - "DAC_OVERRIDE"
     environment:
       MARIADB_AUTO_UPGRADE: "1"
       MARIADB_DISABLE_UPGRADE_BACKUP: "1"
@@ -74,6 +87,14 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
+      - "FOWNER"
+      - "DAC_OVERRIDE"
     volumes:
       - "${DOCKER_DATA_DIR:?error}/${COMPOSE_PROJECT_NAME:?error}/db-backups:/backup:z"
     environment:

--- a/docker/matomo/compose.yaml
+++ b/docker/matomo/compose.yaml
@@ -5,6 +5,12 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
     environment:
       MATOMO_DATABASE_HOST: "db"
       MATOMO_DATABASE_ADAPTER: "mysql"
@@ -33,6 +39,13 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
+      - "DAC_OVERRIDE"
     command:
       - "--max-allowed-packet=64MB"
     environment:
@@ -61,6 +74,14 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
+      - "FOWNER"
+      - "DAC_OVERRIDE"
     volumes:
       - "${DOCKER_DATA_DIR:?error}/${COMPOSE_PROJECT_NAME:?error}/db-backups:/backup:z"
     environment:

--- a/docker/missions/compose.yaml
+++ b/docker/missions/compose.yaml
@@ -6,6 +6,10 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "NET_BIND_SERVICE"
     volumes:
       - "./browse.html:/templates/browse.html:ro,Z"
       - "missions:/srv/mpmissions:ro"

--- a/docker/nextcloud/compose.yaml
+++ b/docker/nextcloud/compose.yaml
@@ -5,6 +5,12 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
     environment:
       TZ: "Europe/Berlin"
       REDIS_HOST: "redis"
@@ -44,7 +50,7 @@ services:
       db:
         condition: "service_healthy"
       redis:
-        condition: "service_started"
+        condition: "service_healthy"
 
   cron:
     image: "nextcloud:34.0.2-apache"
@@ -53,6 +59,12 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
     environment:
       TZ: "Europe/Berlin"
     # volumes must be identical to the app container
@@ -65,7 +77,7 @@ services:
       db:
         condition: "service_healthy"
       redis:
-        condition: "service_started"
+        condition: "service_healthy"
 
   redis:
     image: "redis:8.8.1-alpine"
@@ -73,8 +85,22 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
+      - "FOWNER"
+      - "DAC_OVERRIDE"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      start_period: "10s"
+      interval: "10s"
+      timeout: "5s"
+      retries: 3
     volumes:
-      - "redis:/data:Z"
+      - "redis:/data:z"
 
   db:
     image: "mariadb:lts"
@@ -83,6 +109,13 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
+      - "DAC_OVERRIDE"
     environment:
       MARIADB_AUTO_UPGRADE: "1"
       MARIADB_DISABLE_UPGRADE_BACKUP: "1"
@@ -108,6 +141,14 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
+      - "FOWNER"
+      - "DAC_OVERRIDE"
     volumes:
       - "${DOCKER_DATA_DIR:?error}/${COMPOSE_PROJECT_NAME:?error}/db-backups:/backup:z"
     environment:

--- a/docker/ocap/compose.yaml
+++ b/docker/ocap/compose.yaml
@@ -5,6 +5,14 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
+      - "FOWNER"
+      - "DAC_OVERRIDE"
     environment:
       OCAP_SECRET: "${OCAP_SECRET:?error}"
       OCAP_CUSTOMIZE_ENABLED: "true"

--- a/docker/steam-oidc/compose.yaml
+++ b/docker/steam-oidc/compose.yaml
@@ -5,6 +5,8 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
     environment:
       TZ: "Europe/Berlin"
       OpenId__RedirectUri: "${REDIRECT_URI:?error}"

--- a/docker/traefik-log-dashboard/compose.yaml
+++ b/docker/traefik-log-dashboard/compose.yaml
@@ -5,6 +5,14 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
+      - "FOWNER"
+      - "DAC_OVERRIDE"
     healthcheck:
       test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:5000/api/logs/status" ]
       interval: 2m
@@ -30,6 +38,14 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
+      - "FOWNER"
+      - "DAC_OVERRIDE"
     depends_on:
       agent:
         condition: "service_healthy"

--- a/docker/traefik/compose.yaml
+++ b/docker/traefik/compose.yaml
@@ -5,6 +5,12 @@ services:
     security_opt:
       - "label:disable"
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "CHOWN"
+      - "SETUID"
+      - "SETGID"
     environment:
       CONTAINERS: 1
     volumes:
@@ -19,6 +25,10 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
+    cap_add:
+      - "NET_BIND_SERVICE"
     ports:
       - "${ENTRYPOINT_INTERNAL_IPV4:?error}:80:8080"
       - "${ENTRYPOINT_INTERNAL_IPV4:?error}:443:8443"
@@ -32,7 +42,6 @@ services:
       - "[${ENTRYPOINT_EXTERNAL_IPV6:?error}]:80:80"
       - "[${ENTRYPOINT_EXTERNAL_IPV6:?error}]:443:443"
       - "[${ENTRYPOINT_EXTERNAL_IPV6:?error}]:443:443/udp" # http3
-      - "8090:8090"
     healthcheck:
       test: [ 'CMD', 'traefik', 'healthcheck', '--ping' ]
     volumes:
@@ -52,7 +61,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.traefik.entrypoints: "websecure-internal"
-      traefik.http.routers.traefik.rule: "Host(`traefik.${DOMAINNAME_1?error}`)"
+      traefik.http.routers.traefik.rule: "Host(`traefik.${DOMAINNAME_1:?error}`)"
       traefik.http.routers.traefik.service: "api@internal"
       traefik.http.routers.traefik.middlewares: "authentik"
       traefik.http.middlewares.xff2realip.plugin.traefik-xff-to-xrealip.depth: 0
@@ -63,6 +72,8 @@ services:
     restart: "unless-stopped"
     security_opt:
       - "no-new-privileges:true"
+    cap_drop:
+      - "ALL"
     networks:
       proxy:
     labels:
@@ -162,7 +173,7 @@ configs:
       
       api:
         dashboard: true
-        insecure: true
+        insecure: false
       
       ping: {}
       


### PR DESCRIPTION
Ich nutze bei mir [CAPS](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container) und habe das hier ebenfalls umgesetzt. Bei Nextcloud bin ich mir allerdings nicht zu 100 % sicher, ob alle notwendigen CAPs enthalten sind, aber es sollte passen.

Des Weiteren ist mir aufgefallen, dass `:z` nicht konsequent verwendet wird.

Außerdem fehlte teilweise beim `?error` der Doppelpunkt davor. Nach meinem Verständnis ist das dann wirkungslos, da der String leer bleibt.

---

Ein Fehler der mir noch aufgefallen ist beim Nachrichten-Bot, den ich noch nicht angepasst habe,

```yaml
volumes:
  - "data:/app/data"
```

fehlt doch

```yaml
- "${DOCKER_DATA_DIR:?error}/${COMPOSE_PROJECT_NAME:?error}"
```

Oder übersehe ich hier etwas?
